### PR TITLE
Dropped uk-link-reset class from dropdowns menus

### DIFF
--- a/_includes/navbar-lower-menu.html
+++ b/_includes/navbar-lower-menu.html
@@ -5,7 +5,7 @@
     {% if site.data.taxon_list %}
     {% assign genera = site.data.taxon_list | group_by: "genus"  %}
     <div class="uk-navbar-dropdown uk-width-auto" uk-dropdown="delay-hide: 0;">
-      <ul class="uk-nav uk-navbar-dropdown-nav uk-link-reset">
+      <ul class="uk-nav uk-navbar-dropdown-nav">
       {% for genus in genera %}
         {% for organism in genus.items %}
           {% if organism.category == "main" %}
@@ -23,7 +23,7 @@
     {% if site.data.tools %}
     {% assign groups = site.data.tools | group_by: "category" | sort: "name" %}
     <div class="uk-navbar-dropdown uk-width-auto" uk-dropdown="delay-hide: 0;">
-      <ul class="uk-nav uk-navbar-dropdown-nav uk-link-reset">
+      <ul class="uk-nav uk-navbar-dropdown-nav">
       {% for group in groups %}
         {% for item in group.items %}
           <li><a href="{{ item.url }}">{{ item.name }}</a></li>

--- a/_includes/navbar-menu.html
+++ b/_includes/navbar-menu.html
@@ -5,7 +5,7 @@
     {% if site.data.taxon_list %}
     {% assign genera = site.data.taxon_list | group_by: "genus"  %}
     <div class="uk-navbar-dropdown uk-width-auto" uk-dropdown="delay-hide: 0;">
-      <ul class="uk-nav uk-navbar-dropdown-nav uk-link-reset">
+      <ul class="uk-nav uk-navbar-dropdown-nav">
       {% for genus in genera %}
         {% for organism in genus.items %}
           {% if organism.category == "main" %}
@@ -23,7 +23,7 @@
     {% if site.data.tools %}
     {% assign groups = site.data.tools | group_by: "category" | sort: "name" %}
     <div class="uk-navbar-dropdown uk-width-auto" uk-dropdown="delay-hide: 0;">
-      <ul class="uk-nav uk-navbar-dropdown-nav uk-link-reset">
+      <ul class="uk-nav uk-navbar-dropdown-nav">
       {% for group in groups %}
         {% for item in group.items %}
           <li><a href="{{ item.url }}">{{ item.name }}</a></li>


### PR DESCRIPTION
Merging without review since this solution has already been tested and deployed; see [theme issue #67](https://github.com/legumeinfo/jekyll-theme-legumeinfo/issues/67) and [starter issue #11](https://github.com/legumeinfo/jekyll-starter-legumeinfo/issues/11).